### PR TITLE
[Refactoring] Swiftバージョンを5.9に更新

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: macos-latest
 
     steps: 
-    - uses: swift-actions/setup-swift@65540b95f51493d65f5e59e97dcef9629ddf11bf
+    - uses: swift-actions/setup-swift@150267bf6ba01f9d942a4bd55aa2f35ba586767d
       with:
-        swift-version: "5.8"
+        swift-version: "5.9"
     - uses: actions/checkout@v3
     - name: Build
       run: swift build -Xswiftc -strict-concurrency=complete -v

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -9,7 +9,9 @@ let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
     .enableUpcomingFeature("ImplicitOpenExistentials"),
-    .enableUpcomingFeature("StrictConcurrency")
+    .enableUpcomingFeature("StrictConcurrency"),
+    .enableUpcomingFeature("DisableOutwardActorInference"),
+    .enableUpcomingFeature("ImportObjcForwardDeclarations")
 ]
 let package = Package(
     name: "AzooKeyKanakanjiConverter",


### PR DESCRIPTION
https://github.com/ensan-hcl/azooKey/issues/281 の一環。

* CIを更新
* PackageのSwiftバージョンを更新
* upcoming-feature-flagを追加