### PR TITLE
[Performance] 変換結果をUniqueする処理を高速化

### DIFF
--- a/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
@@ -113,12 +113,14 @@ import SwiftUtils
     ///   `candidates`から重複を削除したもの。
     private func getUniqueCandidate(_ candidates: some Sequence<Candidate>, seenCandidates: Set<String> = []) -> [Candidate] {
         var result = [Candidate]()
+        var textIndex = [String: Int]()
         for candidate in candidates where !candidate.text.isEmpty && !seenCandidates.contains(candidate.text) {
-            if let index = result.firstIndex(where: {$0.text == candidate.text}) {
+            if let index = textIndex[candidate.text] {
                 if result[index].value < candidate.value || result[index].correspondingCount < candidate.correspondingCount {
                     result[index] = candidate
                 }
             } else {
+                textIndex[candidate.text] = result.endIndex
                 result.append(candidate)
             }
         }


### PR DESCRIPTION
UniqueにするためにfirstIndexで何度もStringの比較を行っていたので、Dictionaryを使って比較を減らした。これによって全体の3%程度の処理時間が不要になる。