### PR TITLE
[Performance] LOUDSのinit処理を高速化

### DIFF
--- a/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
@@ -29,10 +29,11 @@ struct LOUDS: Sendable {
             char2nodeIndices[Int(value)].append(i)
         }
         self.char2nodeIndices = consume char2nodeIndices
-        var rankLarge: [UInt32] = [0]
-        rankLarge.reserveCapacity(bytes.count)
-        for byte in bytes {
-            rankLarge.append(rankLarge.last! &+ UInt32(Self.unit &- byte.nonzeroBitCount))
+        var rankLarge: [UInt32] = .init(repeating: 0, count: bytes.count + 1)
+        rankLarge.withUnsafeMutableBufferPointer { buffer in
+            for (i, byte) in zip(bytes.indices, bytes) {
+                buffer[i + 1] = buffer[i] &+ UInt32(Self.unit &- byte.nonzeroBitCount)
+            }
         }
         self.rankLarge = consume rankLarge
     }

--- a/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
@@ -52,7 +52,12 @@ struct LOUDS: Sendable {
                 break
             }
         }
-        guard let i = (Int(left) &+ 1 ..< self.bits.endIndex).first(where: {(index: Int) in self.rankLarge[index &+ 1] >= parentNodeIndex}) else {
+        var i: Int?
+        for index in left &+ 1 ..< self.bits.endIndex where self.rankLarge[index &+ 1] >= parentNodeIndex {
+            i = index
+            break
+        }
+        guard let i else {
             return 0 ..< 0
         }
 

--- a/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
@@ -58,21 +58,25 @@ struct LOUDS: Sendable {
             i = index
             break
         }
-        var left2 = 0, right2 = self.rankLarge.endIndex - 1
-        var result = self.rankLarge.endIndex
-        while left2 <= right2 {
-            let mid = (left2 + right2) / 2
-            if self.rankLarge[mid] >= parentNodeIndex {
-                result = mid
-                right2 = mid - 1
-            } else {
-                left2 = mid + 1
-            }
-        }
         guard let i else {
             return 0 ..< 0
         }
-        assert(i == result - 1)
+        let i2 = {
+            var left = parentNodeIndex >> Self.uExp
+            var right = self.rankLarge.endIndex - 1
+            var i = self.rankLarge.endIndex
+            while left <= right {
+                let mid = (left + right) / 2
+                if self.rankLarge[mid] >= parentNodeIndex {
+                    i = mid
+                    right = mid - 1
+                } else {
+                    left = mid + 1
+                }
+            }
+            return i - 1
+        }()
+        assert(i == i2)
 
         return self.bits.withUnsafeBufferPointer {(buffer: UnsafeBufferPointer<Unit>) -> Range<Int> in
             // 探索パート②

--- a/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
@@ -10,6 +10,8 @@ import Foundation
 
 /// LOUDS
 struct LOUDS: Sendable {
+    private static let prefixOne: UInt64 = (1 << 63)
+
     private typealias Unit = UInt64
     private static let unit = 64
     private static let uExp = 6
@@ -64,6 +66,22 @@ struct LOUDS: Sendable {
             for _ in  0 ..< parentNodeIndex - Int(self.rankLarge[i]) {
                 k = ((~(byte << k)).leadingZeroBitCount &+ k &+ 1) % Self.unit
             }
+            let k2 = {
+                let dif = Int(self.rankLarge[i &+ 1]) &- parentNodeIndex   // 0の数の超過分
+                var count = Unit(Self.unit &- byte.nonzeroBitCount) // 0の数
+                var k = Self.unit
+
+                for c in 0 ..< Self.unit {
+                    if count == dif {
+                        k = c
+                        break
+                    }
+                    // byteの上からc桁めが0なら == (byte << 0)が100………00より小さければ == 最初の1桁を一番下に持ってきた値そのもの
+                    count &-= (byte << c) < Self.prefixOne ? 1:0
+                }
+                return k
+            }()
+            assert(k == k2)
             let start = (i << Self.uExp) &+ k &- parentNodeIndex &+ 1
             // ちょうどparentNodeIndex個の0がi番目にあるかどうか
             if self.rankLarge[i &+ 1] == parentNodeIndex {
@@ -74,13 +92,18 @@ struct LOUDS: Sendable {
                 // 最初の0を探す作業
                 // 反転して、先頭から0の数を数えると最初の0の位置が出てくる
                 // Ex. 1110_0000 => [000]1_1111 => 3
-                let a = (~buffer[j]).leadingZeroBitCount % Self.unit
+                let byte2 = buffer[j]
+                let a = (~byte2).leadingZeroBitCount % Self.unit
+                let a2 = (0 ..< Self.unit).first(where: {(byte2 << $0) < Self.prefixOne}) ?? 0
+                assert(a == a2)
                 return start ..< (j << Self.uExp) &+ a &- parentNodeIndex &+ 1
             } else {
                 // difが0以上の場合、k番目以降の初めての0を発見したい
                 // 例えばk=1の場合
-                // Ex. 1011_1101 => 1111_0100 => [0000]_1011 => 4 => 6
-                let a = ((~(byte << (k))).leadingZeroBitCount &+ k) % Self.unit
+                // Ex. 1011_1101 => 0111_1010 => 1000_0101 => 1 => 2
+                let a = ((~(byte << k)).leadingZeroBitCount &+ k) % Self.unit
+                let a2 = (k ..< Self.unit).first(where: {(byte << $0) < Self.prefixOne}) ?? 0
+                assert(a == a2)
                 return start ..< (i << Self.uExp) &+ a &- parentNodeIndex &+ 1
             }
         }

--- a/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
@@ -64,7 +64,7 @@ struct LOUDS: Sendable {
             let byte = buffer[i]
             var k = 0
             for _ in  0 ..< parentNodeIndex - Int(self.rankLarge[i]) {
-                k = ((~(byte << k)).leadingZeroBitCount &+ k &+ 1) % Self.unit
+                k = (~(byte << k)).leadingZeroBitCount &+ k &+ 1
             }
             let k2 = {
                 let dif = Int(self.rankLarge[i &+ 1]) &- parentNodeIndex   // 0の数の超過分

--- a/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
@@ -44,40 +44,22 @@ struct LOUDS: Sendable {
         // rankLargeは左側の0の数を示すので、difを取っている
         // まず最低限の絞り込みを行う。leftを探索する。
         // 探しているのは、startIndexが含まれるbitsのindex `i`
-        var left = (parentNodeIndex >> Self.uExp) &- 1
-        while true {
-            let dif = parentNodeIndex &- Int(self.rankLarge[Int(left) &+ 1])
-            if dif >= Self.unit {
-                left &+= dif >> Self.uExp
+        var left = parentNodeIndex >> Self.uExp
+        var right = self.rankLarge.endIndex - 1
+        var i = self.rankLarge.endIndex
+        while left <= right {
+            let mid = (left + right) / 2
+            if self.rankLarge[mid] >= parentNodeIndex {
+                i = mid
+                right = mid - 1
             } else {
-                break
+                left = mid + 1
             }
         }
-        var i: Int?
-        for index in left &+ 1 ..< self.bits.endIndex where self.rankLarge[index &+ 1] >= parentNodeIndex {
-            i = index
-            break
-        }
-        guard let i else {
+        guard i != self.rankLarge.endIndex else {
             return 0 ..< 0
         }
-        let i2 = {
-            var left = parentNodeIndex >> Self.uExp
-            var right = self.rankLarge.endIndex - 1
-            var i = self.rankLarge.endIndex
-            while left <= right {
-                let mid = (left + right) / 2
-                if self.rankLarge[mid] >= parentNodeIndex {
-                    i = mid
-                    right = mid - 1
-                } else {
-                    left = mid + 1
-                }
-            }
-            return i - 1
-        }()
-        assert(i == i2)
-
+        i -= 1
         return self.bits.withUnsafeBufferPointer {(buffer: UnsafeBufferPointer<Unit>) -> Range<Int> in
             // 探索パート②
             // 目標はparentNodeIndex番目の0の位置である`k`の発見

--- a/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/LOUDS/LOUDS.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import simd
 
 /// LOUDS
 struct LOUDS: Sendable {
@@ -57,9 +58,21 @@ struct LOUDS: Sendable {
             i = index
             break
         }
+        var left2 = 0, right2 = self.rankLarge.endIndex - 1
+        var result = self.rankLarge.endIndex
+        while left2 <= right2 {
+            let mid = (left2 + right2) / 2
+            if self.rankLarge[mid] >= parentNodeIndex {
+                result = mid
+                right2 = mid - 1
+            } else {
+                left2 = mid + 1
+            }
+        }
         guard let i else {
             return 0 ..< 0
         }
+        assert(i == result - 1)
 
         return self.bits.withUnsafeBufferPointer {(buffer: UnsafeBufferPointer<Unit>) -> Range<Int> in
             // 探索パート②


### PR DESCRIPTION
二重のArrayで持っていた部分をflattenしたデータにすることで、構築時の時間コストを抑えた。2%程度速度改善が得られる