### PR TITLE
[Test] @MainActorのテストケースクラスをasyncなtestケースに変更

### DIFF
--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/CandidateTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/CandidateTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import KanaKanjiConverterModule
 
-@MainActor final class CandidateTests: XCTestCase {
+final class CandidateTests: XCTestCase {
     // テンプレートのパース
     func testParseTemplate() throws {
         do {

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/ConvesionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/ConvesionTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import KanaKanjiConverterModule
 
-@MainActor final class ConverterTests: XCTestCase {
+final class ConverterTests: XCTestCase {
     func requestOptions() -> ConvertRequestOptions {
         ConvertRequestOptions(
             N_best: 5,
@@ -31,13 +31,13 @@ import XCTest
     }
 
     // 変換されてはいけないケースを示す
-    func testMustNotCases() throws {
+    func testMustNotCases() async throws {
         do {
             // 改行文字に対して本当に改行が入ってしまうケース
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             var c = ComposingText()
             c.insertAtCursorPosition("\\n", inputStyle: .direct)
-            let results = converter.requestCandidates(c, options: requestOptions())
+            let results = await converter.requestCandidates(c, options: requestOptions())
             XCTAssertFalse(results.mainResults.contains(where: {$0.text == "\n"}))
         }
     }

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/EmailAddressConversionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/EmailAddressConversionTests.swift
@@ -9,7 +9,7 @@
 @testable import KanaKanjiConverterModule
 import XCTest
 
-@MainActor final class EmailAddressConversionTests: XCTestCase {
+final class EmailAddressConversionTests: XCTestCase {
     func makeDirectInput(direct input: String) -> ComposingText {
         ComposingText(
             convertTargetCursorPosition: input.count,
@@ -18,11 +18,11 @@ import XCTest
         )
     }
 
-    func testtoEmailAddressCandidates() throws {
+    func testtoEmailAddressCandidates() async throws {
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "azooKey@")
-            let result = converter.toEmailAddressCandidates(input)
+            let result = await converter.toEmailAddressCandidates(input)
             XCTAssertFalse(result.isEmpty)
             XCTAssertTrue(result.contains(where: {$0.text == "azooKey@gmail.com"}))
             XCTAssertTrue(result.contains(where: {$0.text == "azooKey@icloud.com"}))
@@ -31,9 +31,9 @@ import XCTest
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "my.dev_az@")
-            let result = converter.toEmailAddressCandidates(input)
+            let result = await converter.toEmailAddressCandidates(input)
             XCTAssertFalse(result.isEmpty)
             XCTAssertTrue(result.contains(where: {$0.text == "my.dev_az@gmail.com"}))
             XCTAssertTrue(result.contains(where: {$0.text == "my.dev_az@icloud.com"}))
@@ -42,9 +42,9 @@ import XCTest
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "@")
-            let result = converter.toEmailAddressCandidates(input)
+            let result = await converter.toEmailAddressCandidates(input)
             XCTAssertFalse(result.isEmpty)
             XCTAssertTrue(result.contains(where: {$0.text == "@gmail.com"}))
             XCTAssertTrue(result.contains(where: {$0.text == "@icloud.com"}))

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/UnicodeConversionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/UnicodeConversionTests.swift
@@ -9,7 +9,7 @@
 @testable import KanaKanjiConverterModule
 import XCTest
 
-@MainActor final class UnicodeConversionTests: XCTestCase {
+final class UnicodeConversionTests: XCTestCase {
     func makeDirectInput(direct input: String) -> ComposingText {
         ComposingText(
             convertTargetCursorPosition: input.count,
@@ -18,53 +18,53 @@ import XCTest
         )
     }
 
-    func testFromUnicode() throws {
+    func testFromUnicode() async throws {
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "U+3042")
-            let result = converter.unicodeCandidates(input)
+            let result = await converter.unicodeCandidates(input)
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result[0].text, "あ")
         }
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "U+1F607")
-            let result = converter.unicodeCandidates(input)
+            let result = await converter.unicodeCandidates(input)
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result[0].text, "😇")
         }
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "u+3042")
-            let result = converter.unicodeCandidates(input)
+            let result = await converter.unicodeCandidates(input)
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result[0].text, "あ")
         }
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "U3042")
-            let result = converter.unicodeCandidates(input)
+            let result = await converter.unicodeCandidates(input)
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result[0].text, "あ")
         }
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "u3042")
-            let result = converter.unicodeCandidates(input)
+            let result = await converter.unicodeCandidates(input)
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result[0].text, "あ")
         }
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "U+61")
-            let result = converter.unicodeCandidates(input)
+            let result = await converter.unicodeCandidates(input)
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result[0].text, "a")
         }
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "U+189")
-            let result = converter.unicodeCandidates(input)
+            let result = await converter.unicodeCandidates(input)
             XCTAssertEqual(result.count, 1)
             XCTAssertEqual(result[0].text, "Ɖ")
         }

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/WarekiConversionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/WarekiConversionTests.swift
@@ -9,7 +9,7 @@
 @testable import KanaKanjiConverterModule
 import XCTest
 
-@MainActor final class WarekiConversionTests: XCTestCase {
+final class WarekiConversionTests: XCTestCase {
     func makeDirectInput(direct input: String) -> ComposingText {
         ComposingText(
             convertTargetCursorPosition: input.count,
@@ -18,11 +18,11 @@ import XCTest
         )
     }
 
-    func testSeireki2Wareki() throws {
+    func testSeireki2Wareki() async throws {
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "2019ねん")
-            let result = converter.toWarekiCandidates(input)
+            let result = await converter.toWarekiCandidates(input)
             XCTAssertEqual(result.count, 2)
             if result.count == 2 {
                 XCTAssertEqual(result[0].text, "令和元年")
@@ -31,9 +31,9 @@ import XCTest
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "2020ねん")
-            let result = converter.toWarekiCandidates(input)
+            let result = await converter.toWarekiCandidates(input)
             XCTAssertEqual(result.count, 1)
             if result.count == 1 {
                 XCTAssertEqual(result[0].text, "令和2年")
@@ -41,9 +41,9 @@ import XCTest
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "2001ねん")
-            let result = converter.toWarekiCandidates(input)
+            let result = await converter.toWarekiCandidates(input)
             XCTAssertEqual(result.count, 1)
             if result.count == 1 {
                 XCTAssertEqual(result[0].text, "平成13年")
@@ -51,9 +51,9 @@ import XCTest
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "1945ねん")
-            let result = converter.toWarekiCandidates(input)
+            let result = await converter.toWarekiCandidates(input)
             XCTAssertEqual(result.count, 1)
             if result.count == 1 {
                 XCTAssertEqual(result[0].text, "昭和20年")
@@ -61,9 +61,9 @@ import XCTest
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "9999ねん")
-            let result = converter.toWarekiCandidates(input)
+            let result = await converter.toWarekiCandidates(input)
             XCTAssertEqual(result.count, 1)
             if result.count == 1 {
                 XCTAssertEqual(result[0].text, "令和7981年")
@@ -72,35 +72,35 @@ import XCTest
 
         // invalid cases
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "せいれき2001ねん")
-            let result = converter.toWarekiCandidates(input)
+            let result = await converter.toWarekiCandidates(input)
             XCTAssertTrue(result.isEmpty)
         }
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "1582ねん")
-            let result = converter.toWarekiCandidates(input)
+            let result = await converter.toWarekiCandidates(input)
             XCTAssertTrue(result.isEmpty)
         }
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "10000ねん")
-            let result = converter.toWarekiCandidates(input)
+            let result = await converter.toWarekiCandidates(input)
             XCTAssertTrue(result.isEmpty)
         }
 
     }
 
-    func testWareki2Seireki() throws {
+    func testWareki2Seireki() async throws {
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = ComposingText(
                 convertTargetCursorPosition: 8,
                 input: "れいわがんねん".map {.init(character: $0, inputStyle: .direct)},
                 convertTarget: "れいわがんねん"
             )
-            let result = converter.toSeirekiCandidates(input)
+            let result = await converter.toSeirekiCandidates(input)
             XCTAssertEqual(result.count, 1)
             if result.count == 1 {
                 XCTAssertEqual(result[0].text, "2019年")
@@ -108,13 +108,13 @@ import XCTest
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = ComposingText(
                 convertTargetCursorPosition: 8,
                 input: "れいわ1ねん".map {.init(character: $0, inputStyle: .direct)},
                 convertTarget: "れいわ1ねん"
             )
-            let result = converter.toSeirekiCandidates(input)
+            let result = await converter.toSeirekiCandidates(input)
             XCTAssertEqual(result.count, 1)
             if result.count == 1 {
                 XCTAssertEqual(result[0].text, "2019年")
@@ -122,13 +122,13 @@ import XCTest
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = ComposingText(
                 convertTargetCursorPosition: 8,
                 input: "しょうわ25ねん".map {.init(character: $0, inputStyle: .direct)},
                 convertTarget: "しょうわ25ねん"
             )
-            let result = converter.toSeirekiCandidates(input)
+            let result = await converter.toSeirekiCandidates(input)
             XCTAssertEqual(result.count, 1)
             if result.count == 1 {
                 XCTAssertEqual(result[0].text, "1950年")
@@ -136,13 +136,13 @@ import XCTest
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = ComposingText(
                 convertTargetCursorPosition: 8,
                 input: "めいじ9ねん".map {.init(character: $0, inputStyle: .direct)},
                 convertTarget: "めいじ9ねん"
             )
-            let result = converter.toSeirekiCandidates(input)
+            let result = await converter.toSeirekiCandidates(input)
             XCTAssertEqual(result.count, 1)
             if result.count == 1 {
                 XCTAssertEqual(result[0].text, "1876年")
@@ -151,16 +151,16 @@ import XCTest
 
         // invalid cases
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "れいわ100ねん")
-            let result = converter.toSeirekiCandidates(input)
+            let result = await converter.toSeirekiCandidates(input)
             XCTAssertTrue(result.isEmpty)
         }
 
         do {
-            let converter = KanaKanjiConverter()
+            let converter = await KanaKanjiConverter()
             let input = makeDirectInput(direct: "けいおう5ねん")
-            let result = converter.toSeirekiCandidates(input)
+            let result = await converter.toSeirekiCandidates(input)
             XCTAssertTrue(result.isEmpty)
         }
     }


### PR DESCRIPTION
Linux上でテストが成功しないため、より一般的なasyncなtestケースに乗り換えることで成功するようになる。