### PR TITLE
[Tool] cliツールとして`anco`を追加

### DIFF
--- a/Docs/cli.md
+++ b/Docs/cli.md
@@ -1,0 +1,25 @@
+#  anco (azooKey Cli)
+
+`anco`コマンドにより、AzooKeyKanaKanjiConverterをCliで利用することができます。`anco`はデバッグ用ツールの位置付けです。
+
+`anco`を利用するには、最初にinstallが必要です。
+
+```
+sh install_cli.sh
+```
+
+例えば以下のように利用できます。
+
+```
+your@pc Desktop % anco にほんごにゅうりょく --disable_prediction -n 10
+日本語入力
+にほんご入力
+2本ご入力
+2本後入力
+2本語入力
+日本語
+2本
+日本
+にほんご
+2本後
+```

--- a/Package.swift
+++ b/Package.swift
@@ -31,13 +31,14 @@ let package = Package(
         .library(
             name: "KanaKanjiConverterModule",
             targets: ["KanaKanjiConverterModule"]
-        )
+        ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-collections", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -72,6 +73,13 @@ let package = Package(
             ],
             swiftSettings: swiftSettings
         ),
+        .executableTarget(
+            name: "CliTool",
+            dependencies: [
+                "KanaKanjiConverterModuleWithDefaultDictionary",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
         .testTarget(
             name: "SwiftUtilsTests",
             dependencies: ["SwiftUtils"],
@@ -88,9 +96,10 @@ let package = Package(
         ),
         .testTarget(
             name: "KanaKanjiConverterModuleWithDefaultDictionaryTests",
-            dependencies: ["KanaKanjiConverterModuleWithDefaultDictionary",
-                           .product(name: "Collections", package: "swift-collections")
-],
+            dependencies: [
+                "KanaKanjiConverterModuleWithDefaultDictionary",
+                .product(name: "Collections", package: "swift-collections")
+            ],
             swiftSettings: swiftSettings
         )
     ]

--- a/Sources/CliTool/Anco.swift
+++ b/Sources/CliTool/Anco.swift
@@ -1,0 +1,13 @@
+import KanaKanjiConverterModuleWithDefaultDictionary
+import ArgumentParser
+
+@main
+public struct Anco: ParsableCommand {
+    public static var configuration = CommandConfiguration(
+        abstract: "Anco is A(zooKey) Kana-Ka(n)ji (co)nverter",
+        subcommands: [Subcommands.Run.self],
+        defaultSubcommand: Subcommands.Run.self
+    )
+
+    public init() {}
+}

--- a/Sources/CliTool/Subcommands/Commands.swift
+++ b/Sources/CliTool/Subcommands/Commands.swift
@@ -1,0 +1,2 @@
+/// namespace for subcommands
+enum Subcommands {}

--- a/Sources/CliTool/Subcommands/RunCommand.swift
+++ b/Sources/CliTool/Subcommands/RunCommand.swift
@@ -1,0 +1,50 @@
+import KanaKanjiConverterModuleWithDefaultDictionary
+import ArgumentParser
+import Foundation
+
+extension Subcommands {
+    struct Run: ParsableCommand {
+        @Argument(help: "ひらがなで表記された入力")
+        var input: String = ""
+
+        @Option(name: [.customLong("config_n_best")], help: "The parameter n (n best parameter) for internal viterbi search.")
+        var configNBest: Int = 10
+        @Option(name: [.customShort("n"), .customLong("top_n")], help: "Display top n candidates.")
+        var displayTopN: Int = 1
+
+        @Flag(name: [.customLong("disable_prediction")], help: "Disable producing prediction candidates.")
+        var disablePrediction = false
+
+        static var configuration = CommandConfiguration(commandName: "run", abstract: "Show help for this utility.")
+
+        @MainActor mutating func run() {
+            let converter = KanaKanjiConverter()
+            var composingText = ComposingText()
+            composingText.insertAtCursorPosition(input, inputStyle: .direct)
+            let result = converter.requestCandidates(composingText, options: requestOptions())
+            for candidate in result.mainResults.prefix(self.displayTopN) {
+                print(candidate.text)
+            }
+        }
+
+        func requestOptions() -> ConvertRequestOptions {
+            .withDefaultDictionary(
+                N_best: configNBest,
+                requireJapanesePrediction: !disablePrediction,
+                requireEnglishPrediction: false,
+                keyboardLanguage: .ja_JP,
+                typographyLetterCandidate: false,
+                unicodeCandidate: true,
+                englishCandidateInRoman2KanaInput: true,
+                fullWidthRomanCandidate: false,
+                halfWidthKanaCandidate: false,
+                learningType: .nothing,
+                maxMemoryCount: 0,
+                shouldResetMemory: false,
+                memoryDirectoryURL: URL(fileURLWithPath: ""),
+                sharedContainerURL: URL(fileURLWithPath: ""),
+                metadata: .init(appVersionString: "anco")
+            )
+        }
+    }
+}

--- a/install_cli.sh
+++ b/install_cli.sh
@@ -1,0 +1,2 @@
+swift build -c release
+cp -f .build/release/CliTool /usr/local/bin/anco


### PR DESCRIPTION
CLI経由でAzooKeyKanaKanjiConverterを利用するため、`anco`を用意した。以下のように利用できる。

```
your@pc Desktop % anco にほんごにゅうりょく --disable_prediction -n 10
日本語入力
にほんご入力
2本ご入力
2本後入力
2本語入力
日本語
2本
日本
にほんご
2本後
```
