### PR TITLE
Refactor dropping "ネン" from string in CalendarCandidate.swift

### DIFF
--- a/Sources/KanaKanjiConverterModule/Converter/CalendarCandidate.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/CalendarCandidate.swift
@@ -48,7 +48,7 @@ extension KanaKanjiConverter {
         }
         var string = string[...]
         // ネンをdropする
-        guard "ネン" == string.suffix(2) else {
+        guard string.hasSuffix("ネン") else {
             return nil
         }
         string = string.dropLast(2)


### PR DESCRIPTION
This pull request refactors the code in CalendarCandidate.swift to improve the dropping of the "ネン" string. The previous implementation used the `suffix` method, but it has been replaced with the `hasSuffix` method for better readability and performance.