### PR TITLE
[Tools] Swift 5.10のCIを追加する

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,15 +10,16 @@ on:
 
 jobs:
   build:
-    name: Swift on ${{ matrix.os }}
+    name: Swift ${{ matrix.swift-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        swift-version: [5.9, 5.10]
     steps:
-    - uses: swift-actions/setup-swift@v2
+    - uses: swift-actions/setup-swift@v1
       with:
-        swift-version: 5.9
+        swift-version: ${{ matrix.swift-version }}
     - uses: actions/checkout@v4
       with:
         submodules: true

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         swift-version: [5.9, 5.10]
     steps:
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@v2
       with:
         swift-version: ${{ matrix.swift-version }}
     - uses: actions/checkout@v4

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        swift-version: [5.9, 5.10]
+        swift-version: ["5.9", "5.10"]
     steps:
     - uses: swift-actions/setup-swift@v2
       with:


### PR DESCRIPTION
This pull request adds CI support for Swift 5.10. It ensures that Swift 5.9 will be supported as long as the CI passes, and will be stopped if it fails. Fixes #66.