### PR TITLE
Update Swift image version to 5.10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Swift",
-    "image": "swift:5.9",
+    "image": "swift:5.10",
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {
             "installZsh": "false",


### PR DESCRIPTION
This pull request updates the Swift image version in the devcontainer.json file to 5.10. It also includes other necessary changes and updates related to the Swift 5.10 version. This resolves issue #68.