### PR TITLE
[Fix] 学習データの更新ロジックを修正

### DIFF
--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -484,6 +484,7 @@ struct TemporalLearningMemoryTrie {
             }
         }
         debug("TemporalLearningMemoryTrie.append before", nodes[index].dataIndices.map {self.dicdata[$0]})
+        debug("TemporalLearningMemoryTrie.append want to append", dicdata)
         for (dicdataElement, metadataElement) in zip(dicdata, metadata) {
             if let dataIndex = nodes[index].dataIndices.first(where: {Self.sameDicdataIfRubyIsEqual(left: self.dicdata[$0], right: dicdataElement)}) {
                 // すでにnodes[index]に同じデータが存在している場合、カウントを加算し、最後に使った日を後の方に変更する

--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -483,6 +483,7 @@ struct TemporalLearningMemoryTrie {
                 index = nextIndex
             }
         }
+        debug("TemporalLearningMemoryTrie.append before", nodes[index].dataIndices.map {self.dicdata[$0]})
         for (dicdataElement, metadataElement) in zip(dicdata, metadata) {
             if let dataIndex = nodes[index].dataIndices.first(where: {Self.sameDicdataIfRubyIsEqual(left: self.dicdata[$0], right: dicdataElement)}) {
                 // すでにnodes[index]に同じデータが存在している場合、カウントを加算し、最後に使った日を後の方に変更する
@@ -502,6 +503,7 @@ struct TemporalLearningMemoryTrie {
                 nodes[index].dataIndices.append(dataIndex)
             }
         }
+        debug("TemporalLearningMemoryTrie.append after", nodes[index].dataIndices.map {self.dicdata[$0]})
     }
 
     /// ルビが同じだとわかっている場合に2つのDicdataElementが同じものか判定する関数

--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -241,8 +241,8 @@ struct LongTermLearningMemory {
                 // 1byteで項目数
                 let itemCount = Int(ltMetadata[metadataOffset ..< metadataOffset + 1].toArray(of: UInt8.self)[0])
                 metadataOffset += 1
-                let metadata = ltMetadata[metadataOffset ..< metadataOffset + itemCount * 5].toArray(of: MetadataElement.self)
-                metadataOffset += itemCount * 5
+                let metadata = ltMetadata[metadataOffset ..< metadataOffset + itemCount * MemoryLayout<MetadataElement>.size].toArray(of: MetadataElement.self)
+                metadataOffset += itemCount * MemoryLayout<MetadataElement>.size
 
                 // バイナリ内部でのindex
                 let startIndex = Int(indices[i])
@@ -257,7 +257,7 @@ struct LongTermLearningMemory {
                 var newMetadata: [MetadataElement] = []
                 assert(elements.count == metadata.count, "elements count and metadata count must be equal.")
                 for (dicdataElement, metadataElement) in zip(elements, metadata) {
-                    debug("LongTermLearningMemory merge trial \(i)", dicdataElement)
+                    debug("LongTermLearningMemory merge trial \(i)", dicdataElement, metadataElement)
                     // 忘却対象である場合は弾く
                     if forgetTargets.contains(dicdataElement) {
                         debug("LongTermLearningMemory merge stopped because it is a forget target", dicdataElement)
@@ -385,8 +385,7 @@ struct LongTermLearningMemory {
         }
         let metadataFileTemp = metadataFileURL(asTemporaryFile: true, directoryURL: directoryURL)
         do {
-            var binary = Data()
-            binary += Data(bytes: [UInt32(metadata.count)], count: 4) // エントリ数をUInt32でマップ
+            let binary = Data(bytes: [UInt32(metadata.count)], count: 4) // エントリ数をUInt32でマップ
             let result = metadata.reduce(into: binary) {
                 $0.append($1.makeBinary())
             }

--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -264,19 +264,24 @@ struct LongTermLearningMemory {
                     if ruby != dicdataElement.ruby {
                         continue
                     }
-                    var dicdataElement = dicdataElement
-                    var metadataElement = metadataElement
-                    guard today >= metadataElement.lastUpdatedDay else {
+                    guard today >= metadataElement.lastUpdatedDay,
+                          today >= metadataElement.lastUsedDay else {
                         // 変なデータが入っているとアンダーフローが起こるため、事前にガードする
                         continue
                     }
+                    guard today - metadataElement.lastUsedDay < 128 else {
+                        // 128日以上使っていない単語は除外
+                        continue
+                    }
+                    var dicdataElement = dicdataElement
+                    var metadataElement = metadataElement
                     // 32日ごとにカウントを半減させる
                     while today - metadataElement.lastUpdatedDay > 32 {
                         metadataElement.count >>= 1
                         metadataElement.lastUpdatedDay += 32
                     }
-                    // カウントがゼロになるか128日以上使っていない単語は除外
-                    if metadataElement.count == 0 || today - metadataElement.lastUsedDay >= 128 {
+                    // カウントがゼロになる場合除外
+                    guard metadataElement.count > 0 else {
                         continue
                     }
                     dicdataElement.baseValue = valueForData(metadata: metadataElement, dicdata: dicdataElement)

--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -492,6 +492,8 @@ struct TemporalLearningMemoryTrie {
                     currentMetadata.count += min(.max - currentMetadata.count, metadataElement.count)
                 }
                 self.dicdata[dataIndex] = dicdataElement
+                // valueを更新する
+                self.dicdata[dataIndex].baseValue = LongTermLearningMemory.valueForData(metadata: self.metadata[dataIndex], dicdata: dicdataElement)
             } else {
                 // まだnodes[index]に同じデータが存在していない場合、data末尾に新しい要素を追加してnodes[index]を更新する
                 let dataIndex = self.dicdata.endIndex

--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -488,7 +488,7 @@ struct TemporalLearningMemoryTrie {
                 index = nextIndex
             }
         }
-        debug("TemporalLearningMemoryTrie.append before", nodes[index].dataIndices.map {self.dicdata[$0]})
+        debug("TemporalLearningMemoryTrie.append after", nodes[index].dataIndices.map {(self.dicdata[$0], self.metadata[$0])})
         debug("TemporalLearningMemoryTrie.append want to append", dicdata)
         for (dicdataElement, metadataElement) in zip(dicdata, metadata) {
             if let dataIndex = nodes[index].dataIndices.first(where: {Self.sameDicdataIfRubyIsEqual(left: self.dicdata[$0], right: dicdataElement)}) {
@@ -509,7 +509,7 @@ struct TemporalLearningMemoryTrie {
                 nodes[index].dataIndices.append(dataIndex)
             }
         }
-        debug("TemporalLearningMemoryTrie.append after", nodes[index].dataIndices.map {self.dicdata[$0]})
+        debug("TemporalLearningMemoryTrie.append after", nodes[index].dataIndices.map {(self.dicdata[$0], self.metadata[$0])})
     }
 
     /// ルビが同じだとわかっている場合に2つのDicdataElementが同じものか判定する関数

--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -257,6 +257,7 @@ struct LongTermLearningMemory {
                 var newMetadata: [MetadataElement] = []
                 assert(elements.count == metadata.count, "elements count and metadata count must be equal.")
                 for (dicdataElement, metadataElement) in zip(elements, metadata) {
+                    debug("LongTermLearningMemory merge trial \(i)", dicdataElement)
                     // 忘却対象である場合は弾く
                     if forgetTargets.contains(dicdataElement) {
                         continue

--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -260,18 +260,22 @@ struct LongTermLearningMemory {
                     debug("LongTermLearningMemory merge trial \(i)", dicdataElement)
                     // 忘却対象である場合は弾く
                     if forgetTargets.contains(dicdataElement) {
+                        debug("LongTermLearningMemory merge stopped because it is a forget target", dicdataElement)
                         continue
                     }
                     if ruby != dicdataElement.ruby {
+                        debug("LongTermLearningMemory merge stopped because dicdataElement has different ruby", dicdataElement, ruby)
                         continue
                     }
                     guard today >= metadataElement.lastUpdatedDay,
                           today >= metadataElement.lastUsedDay else {
                         // 変なデータが入っているとアンダーフローが起こるため、事前にガードする
+                        debug("LongTermLearningMemory merge stopped because metadata is strange", dicdataElement, metadataElement, today)
                         continue
                     }
                     guard today - metadataElement.lastUsedDay < 128 else {
                         // 128日以上使っていない単語は除外
+                        debug("LongTermLearningMemory merge stopped because metadata is strange", dicdataElement, metadataElement, today)
                         continue
                     }
                     var dicdataElement = dicdataElement
@@ -283,6 +287,7 @@ struct LongTermLearningMemory {
                     }
                     // カウントがゼロになる場合除外
                     guard metadataElement.count > 0 else {
+                        debug("LongTermLearningMemory merge stopped because count is zero", dicdataElement, metadataElement)
                         continue
                     }
                     dicdataElement.baseValue = valueForData(metadata: metadataElement, dicdata: dicdataElement)

--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -111,11 +111,11 @@ struct LongTermLearningMemory {
 
         func makeBinary() -> Data {
             var data = Data()
-            var metadata = self.metadata.map {MetadataElement(day: $0.lastUsedDay, count: $0.count)}
+            var metadata: [(UInt16, UInt16, UInt8)] = self.metadata.map {($0.lastUsedDay, $0.lastUsedDay, $0.count)}
             // エントリのカウントを1byteでエンコード
             var count = UInt8(metadata.count)
-            data.append(contentsOf: Data(bytes: &count, count: MemoryLayout<UInt8>.size))
-            data.append(contentsOf: Data(bytes: &metadata, count: MemoryLayout<MetadataElement>.size * metadata.count))
+            data.append(contentsOf: Data(bytes: &count, count: MemoryLayout<UInt8>.stride))
+            data.append(contentsOf: Data(bytes: &metadata, count: MemoryLayout<MetadataElement>.stride * metadata.count))
             return data
         }
     }
@@ -241,8 +241,8 @@ struct LongTermLearningMemory {
                 // 1byteで項目数
                 let itemCount = Int(ltMetadata[metadataOffset ..< metadataOffset + 1].toArray(of: UInt8.self)[0])
                 metadataOffset += 1
-                let metadata = ltMetadata[metadataOffset ..< metadataOffset + itemCount * MemoryLayout<MetadataElement>.size].toArray(of: MetadataElement.self)
-                metadataOffset += itemCount * MemoryLayout<MetadataElement>.size
+                let metadata = ltMetadata[metadataOffset ..< metadataOffset + itemCount * MemoryLayout<MetadataElement>.stride].toArray(of: MetadataElement.self)
+                metadataOffset += itemCount * MemoryLayout<MetadataElement>.stride
 
                 // バイナリ内部でのindex
                 let startIndex = Int(indices[i])
@@ -405,8 +405,8 @@ struct LongTermLearningMemory {
                 while metadataOffset < result.endIndex {
                     let itemCount = result[metadataOffset ..< metadataOffset + 1].toArray(of: UInt8.self)[0]
                     metadataOffset += 1
-                    debug("LongTermLearningMemory", result[metadataOffset ..< metadataOffset + MemoryLayout<MetadataElement>.size * Int(itemCount)].toArray(of: MetadataElement.self))
-                    metadataOffset += MemoryLayout<MetadataElement>.size * Int(itemCount)
+                    debug("LongTermLearningMemory", result[metadataOffset ..< metadataOffset + MemoryLayout<MetadataElement>.stride * Int(itemCount)].toArray(of: MetadataElement.self))
+                    metadataOffset += MemoryLayout<MetadataElement>.stride * Int(itemCount)
                 }
 
             }

--- a/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/LearningMemory.swift
@@ -408,8 +408,12 @@ struct LongTermLearningMemory {
                 while metadataOffset < result.endIndex {
                     let itemCount = result[metadataOffset ..< metadataOffset + 1].toArray(of: UInt8.self)[0]
                     metadataOffset += 1
-                    debug("LongTermLearningMemory", result[metadataOffset ..< metadataOffset + MemoryLayout<MetadataElement>.stride * Int(itemCount)].toArray(of: MetadataElement.self))
-                    metadataOffset += MemoryLayout<MetadataElement>.stride * Int(itemCount)
+                    let metadata: [MetadataElement] = (0 ..< Int(itemCount)).map {
+                        let range = metadataOffset + $0 * MemoryLayout<MetadataElement>.size ..< metadataOffset + ($0 + 1) * MemoryLayout<MetadataElement>.size
+                        return result[range].toArray(of: MetadataElement.self)[0]
+                    }
+                    metadataOffset += MemoryLayout<MetadataElement>.size * Int(itemCount)
+                    debug("LongTermLearningMemory", metadata)
                 }
 
             }

--- a/Sources/KanaKanjiConverterModule/LOUDS/extension LOUDS.swift
+++ b/Sources/KanaKanjiConverterModule/LOUDS/extension LOUDS.swift
@@ -90,7 +90,7 @@ extension LOUDS {
             debug("getDataForLoudstxt3: failed to parse", dicdata)
             return []
         }
-        for (index, substring) in substrings[1...].enumerated() {
+        for (index, substring) in zip(dicdata.indices, substrings[1...]) {
             guard let word = String(data: substring, encoding: .utf8) else {
                 debug("getDataForLoudstxt3: failed to parse", ruby)
                 continue


### PR DESCRIPTION
Fix https://github.com/ensan-hcl/azooKey/issues/461


## Description
https://github.com/ensan-hcl/azooKey/issues/461 で報告したとおり、学習データの更新ロジックに深刻な不具合があることがわかった。本PRはこれを修正する。

修正前後のデータ形式は互換性を持たないため、マイグレーションが必要となる。この実装は次のように考えて実装する。


### 修正前後
修正前に`MetadataElement(lastUsedDay: 42, lastUpdateDay: 42, count: 1...7)`を保存する場合、以下のような形で保存される。これは5バイト7個分と想定して35バイトのデータとなっている。ここから修正前のコードで読み出しを行うと、35バイト中30バイト分（5データ）を有効なデータとして読み出せて、差し引き2個が捨てられる。

```
  [0] = 42
  [1] = 0
  [2] = 42
  [3] = 0
  [4] = 1
  [5] = 0
  [6] = 42
  [7] = 0
  [8] = 42
  [9] = 0
  [10] = 2
  [11] = 0
  [12] = 42
  [13] = 0
  [14] = 42
  [15] = 0
  [16] = 3
  [17] = 0
  [18] = 42
  [19] = 0
  [20] = 42
  [21] = 0
  [22] = 4
  [23] = 0
  [24] = 42
  [25] = 0
  [26] = 42
  [27] = 0
  [28] = 5
  [29] = 0
  [30] = 42
  [31] = 0
  [32] = 42
  [33] = 0
  [34] = 6
```
修正後のコードでこのデータを読み出そうとした場合、5バイトずつ読み出す。このため、最初の5バイトはそのまま解釈可能だが、残りは解釈が変わる。具体的には`MetadataElement(42*256, 42*256, 0), MetadataElement(2, 42, 42), MetadataElement(3*256, 42*256, 0), MetadataElement(42, 4, 42), MetadataElement(42* 256, 5*256, 0), MetadataElement(42, 42, 6)`のようになる。
このうち、異常値となるのはdayの情報がtodayを超えてしまうものである。これは新規にロジックを追加し、todayを超えるdayが指定されている場合、メタデータをリセットするように変更した。また、dayの情報がtodayより遥かに小さくなる場合は処理中で削除される。カウントが0になる場合も同様に処理中で削除される。どのパターンであっても、システムに深刻な不具合をもたらすことは考えられない。
なお、このような長いデータは同じルビに複数の単語が学習されているケースでのみ起こり、大半のケースではそもそも発生しない。

このことから、本マイグレーションでは単に読み替えを行うことで対応する。