### PR TITLE
[cli] スコアを表示するオプションを追加

### DIFF
--- a/Sources/CliTool/Subcommands/RunCommand.swift
+++ b/Sources/CliTool/Subcommands/RunCommand.swift
@@ -15,6 +15,9 @@ extension Subcommands {
         @Flag(name: [.customLong("disable_prediction")], help: "Disable producing prediction candidates.")
         var disablePrediction = false
 
+        @Flag(name: [.customLong("report_score")], help: "Show internal score for the candidate.")
+        var reportScore = false
+
         static var configuration = CommandConfiguration(commandName: "run", abstract: "Show help for this utility.")
 
         @MainActor mutating func run() {
@@ -23,7 +26,11 @@ extension Subcommands {
             composingText.insertAtCursorPosition(input, inputStyle: .direct)
             let result = converter.requestCandidates(composingText, options: requestOptions())
             for candidate in result.mainResults.prefix(self.displayTopN) {
-                print(candidate.text)
+                if self.reportScore {
+                    print("\(candidate.text) \(bold: "score:") \(candidate.value)")
+                } else {
+                    print(candidate.text)
+                }
             }
         }
 


### PR DESCRIPTION
`--report_score`オプションを追加した。

```
% anco ひじょうにびみだ -n 5 --disable_prediction --report_score
非常に美味だ score: -35.7767
ひじょうに美味だ score: -38.1344
非情に美味だ score: -41.4822
非常に微見だ score: -43.106007
非常に美味打 score: -45.706997
```