### PR TITLE
[cli] 完全一致変換のみを出力するモードを追加

### DIFF
--- a/Sources/CliTool/Subcommands/RunCommand.swift
+++ b/Sources/CliTool/Subcommands/RunCommand.swift
@@ -15,6 +15,9 @@ extension Subcommands {
         @Flag(name: [.customLong("disable_prediction")], help: "Disable producing prediction candidates.")
         var disablePrediction = false
 
+        @Flag(name: [.customLong("report_score")], help: "Show internal score for the candidate.")
+        var reportScore = false
+
         static var configuration = CommandConfiguration(commandName: "run", abstract: "Show help for this utility.")
 
         @MainActor mutating func run() {
@@ -23,7 +26,11 @@ extension Subcommands {
             composingText.insertAtCursorPosition(input, inputStyle: .direct)
             let result = converter.requestCandidates(composingText, options: requestOptions())
             for candidate in result.mainResults.prefix(self.displayTopN) {
-                print(candidate.text)
+                if self.reportScore {
+                    print("\(candidate.text) \(bold: "score:") \(candidate.value)")
+                } else {
+                    print(candidate.text)
+                }
             }
         }
 

--- a/Sources/KanaKanjiConverterModule/Converter/ConvertRequestOptions.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/ConvertRequestOptions.swift
@@ -49,6 +49,26 @@ public struct ConvertRequestOptions: Sendable {
         self.dictionaryResourceURL = dictionaryResourceURL
     }
 
+    package init(N_best: Int = 10, requireJapanesePrediction: Bool, requireEnglishPrediction: Bool, keyboardLanguage: KeyboardLanguage, typographyLetterCandidate: Bool = false, unicodeCandidate: Bool = true, englishCandidateInRoman2KanaInput: Bool = false, fullWidthRomanCandidate: Bool = false, halfWidthKanaCandidate: Bool = false, learningType: LearningType, maxMemoryCount: Int = 65536, shouldResetMemory: Bool = false, dictionaryResourceURL: URL, memoryDirectoryURL: URL, sharedContainerURL: URL, textReplacer: TextReplacer = TextReplacer(), metadata: ConvertRequestOptions.Metadata, requestQuery: RequestQuery) {
+        self.N_best = N_best
+        self.requireJapanesePrediction = requireJapanesePrediction
+        self.requireEnglishPrediction = requireEnglishPrediction
+        self.keyboardLanguage = keyboardLanguage
+        self.typographyLetterCandidate = typographyLetterCandidate
+        self.unicodeCandidate = unicodeCandidate
+        self.englishCandidateInRoman2KanaInput = englishCandidateInRoman2KanaInput
+        self.fullWidthRomanCandidate = fullWidthRomanCandidate
+        self.halfWidthKanaCandidate = halfWidthKanaCandidate
+        self.learningType = learningType
+        self.maxMemoryCount = maxMemoryCount
+        self.shouldResetMemory = shouldResetMemory
+        self.memoryDirectoryURL = memoryDirectoryURL
+        self.sharedContainerURL = sharedContainerURL
+        self.metadata = metadata
+        self.textReplacer = textReplacer
+        self.dictionaryResourceURL = dictionaryResourceURL
+    }
+
     public var N_best: Int
     public var requireJapanesePrediction: Bool
     public var requireEnglishPrediction: Bool
@@ -70,6 +90,9 @@ public struct ConvertRequestOptions: Sendable {
     public var dictionaryResourceURL: URL
     // メタデータ
     public var metadata: Metadata
+
+    // MARK: プライベートAPI
+    package var requestQuery: RequestQuery = .default
 
     static var `default`: Self {
         Self(
@@ -102,5 +125,10 @@ public struct ConvertRequestOptions: Sendable {
             self.appVersionString = appVersionString
         }
         var appVersionString: String
+    }
+
+    package enum RequestQuery: Sendable {
+        case `default`
+        case 完全一致
     }
 }

--- a/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
@@ -428,6 +428,10 @@ import SwiftUtils
         let sums: [(CandidateData, Candidate)] = clauseResult.map {($0, converter.processClauseCandidate($0))}
         // 文章全体を変換した場合の候補上位5件を作る
         let whole_sentence_unique_candidates = self.getUniqueCandidate(sums.map {$0.1})
+        if case .完全一致 = options.requestQuery {
+            // 完全一致候補のみが要求されている場合、ここで全てのデータを返してreturnする
+            return ConversionResult(mainResults: whole_sentence_unique_candidates.sorted(by: {$0.value > $1.value}), firstClauseResults: [])
+        }
         let sentence_candidates = whole_sentence_unique_candidates.min(count: 5, sortedBy: {$0.value > $1.value})
         // 予測変換を最大3件作成する
         let prediction_candidates: [Candidate] = options.requireJapanesePrediction ? Array(self.getUniqueCandidate(self.getPredictionCandidate(sums, composingText: inputData, options: options)).min(count: 3, sortedBy: {$0.value > $1.value})) : []


### PR DESCRIPTION
```
% anco しかくとさんかく -n 5 --only_whole_conversion --report_score
資格と三角 score: -35.1128
四角と三角 score: -35.4663
視覚と三角 score: -35.8107
資格と参画 score: -36.4517
死角と三角 score: -37.2333
Entropy: 1.6687454757348383
```