### PR TITLE
[Feature] MetadataのAPIをより柔軟にし、任意のアプリ名を指定可能にした

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ let options = ConvertRequestOptions.withDefaultDictionary(
     // ユーザ辞書データのあるディレクトリのURL（書類フォルダを指定）
     sharedContainerURL: .documentsDirectory, 
     // メタデータ
-    metadata: .init(appVersionString: "Version X")
+    metadata: .init(versionString: "You App Version X")
 )
 ```
 
@@ -131,7 +131,7 @@ let options = ConvertRequestOptions(
     // ユーザ辞書データのあるディレクトリのURL（書類フォルダを指定）
     sharedContainerURL: .documentsDirectory, 
     // メタデータ
-    metadata: .init(appVersionString: "Version X")
+    metadata: .init(versionString: "You App Version X")
 )
 ```
 

--- a/Sources/CliTool/Subcommands/DictCommands/ReadCommand.swift
+++ b/Sources/CliTool/Subcommands/DictCommands/ReadCommand.swift
@@ -116,7 +116,7 @@ extension Subcommands.Dict {
                 dictionaryResourceURL: URL(fileURLWithPath: self.dictionaryDirectory),
                 memoryDirectoryURL: URL(fileURLWithPath: self.dictionaryDirectory),
                 sharedContainerURL: URL(fileURLWithPath: self.dictionaryDirectory),
-                metadata: .init(appVersionString: "anco")
+                metadata: .init(versionString: "anco for debugging")
             )
         }
     }

--- a/Sources/CliTool/Subcommands/RunCommand.swift
+++ b/Sources/CliTool/Subcommands/RunCommand.swift
@@ -65,7 +65,7 @@ extension Subcommands {
                 shouldResetMemory: false,
                 memoryDirectoryURL: URL(fileURLWithPath: ""),
                 sharedContainerURL: URL(fileURLWithPath: ""),
-                metadata: .init(appVersionString: "anco")
+                metadata: .init(versionString: "anco for debugging")
             )
             if self.onlyWholeConversion {
                 option.requestQuery = .完全一致

--- a/Sources/KanaKanjiConverterModule/Converter/ConvertRequestOptions.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/ConvertRequestOptions.swift
@@ -29,7 +29,7 @@ public struct ConvertRequestOptions: Sendable {
     ///   - sharedContainerURL: ユーザ辞書など、キーボード外で書き込んだ設定データの保存されているディレクトリを指定します。
     ///   - textReplacer: 予測変換のための置換機を指定します。
     ///   - metadata: メタデータを指定します。詳しくは`ConvertRequestOptions.Metadata`を参照してください。
-    public init(N_best: Int = 10, requireJapanesePrediction: Bool, requireEnglishPrediction: Bool, keyboardLanguage: KeyboardLanguage, typographyLetterCandidate: Bool = false, unicodeCandidate: Bool = true, englishCandidateInRoman2KanaInput: Bool = false, fullWidthRomanCandidate: Bool = false, halfWidthKanaCandidate: Bool = false, learningType: LearningType, maxMemoryCount: Int = 65536, shouldResetMemory: Bool = false, dictionaryResourceURL: URL, memoryDirectoryURL: URL, sharedContainerURL: URL, textReplacer: TextReplacer = TextReplacer(), metadata: ConvertRequestOptions.Metadata) {
+    public init(N_best: Int = 10, requireJapanesePrediction: Bool, requireEnglishPrediction: Bool, keyboardLanguage: KeyboardLanguage, typographyLetterCandidate: Bool = false, unicodeCandidate: Bool = true, englishCandidateInRoman2KanaInput: Bool = false, fullWidthRomanCandidate: Bool = false, halfWidthKanaCandidate: Bool = false, learningType: LearningType, maxMemoryCount: Int = 65536, shouldResetMemory: Bool = false, dictionaryResourceURL: URL, memoryDirectoryURL: URL, sharedContainerURL: URL, textReplacer: TextReplacer = TextReplacer(), metadata: ConvertRequestOptions.Metadata?) {
         self.N_best = N_best
         self.requireJapanesePrediction = requireJapanesePrediction
         self.requireEnglishPrediction = requireEnglishPrediction
@@ -49,7 +49,7 @@ public struct ConvertRequestOptions: Sendable {
         self.dictionaryResourceURL = dictionaryResourceURL
     }
 
-    package init(N_best: Int = 10, requireJapanesePrediction: Bool, requireEnglishPrediction: Bool, keyboardLanguage: KeyboardLanguage, typographyLetterCandidate: Bool = false, unicodeCandidate: Bool = true, englishCandidateInRoman2KanaInput: Bool = false, fullWidthRomanCandidate: Bool = false, halfWidthKanaCandidate: Bool = false, learningType: LearningType, maxMemoryCount: Int = 65536, shouldResetMemory: Bool = false, dictionaryResourceURL: URL, memoryDirectoryURL: URL, sharedContainerURL: URL, textReplacer: TextReplacer = TextReplacer(), metadata: ConvertRequestOptions.Metadata, requestQuery: RequestQuery) {
+    package init(N_best: Int = 10, requireJapanesePrediction: Bool, requireEnglishPrediction: Bool, keyboardLanguage: KeyboardLanguage, typographyLetterCandidate: Bool = false, unicodeCandidate: Bool = true, englishCandidateInRoman2KanaInput: Bool = false, fullWidthRomanCandidate: Bool = false, halfWidthKanaCandidate: Bool = false, learningType: LearningType, maxMemoryCount: Int = 65536, shouldResetMemory: Bool = false, dictionaryResourceURL: URL, memoryDirectoryURL: URL, sharedContainerURL: URL, textReplacer: TextReplacer = TextReplacer(), metadata: ConvertRequestOptions.Metadata?, requestQuery: RequestQuery) {
         self.N_best = N_best
         self.requireJapanesePrediction = requireJapanesePrediction
         self.requireEnglishPrediction = requireEnglishPrediction
@@ -89,7 +89,7 @@ public struct ConvertRequestOptions: Sendable {
     public var sharedContainerURL: URL
     public var dictionaryResourceURL: URL
     // メタデータ
-    public var metadata: Metadata
+    public var metadata: Metadata?
 
     // MARK: プライベートAPI
     package var requestQuery: RequestQuery = .default
@@ -114,17 +114,24 @@ public struct ConvertRequestOptions: Sendable {
             memoryDirectoryURL: (try? FileManager.default.url(for: .libraryDirectory, in: .userDomainMask, appropriateFor: nil, create: false)) ?? Bundle.main.bundleURL,
             // dummy data, won't work
             sharedContainerURL: Bundle.main.bundleURL,
-            metadata: Metadata(appVersionString: "Unknown")
+            metadata: nil
         )
     }
 
     public struct Metadata: Sendable {
         /// - parameters:
         ///   - appVersionString: アプリのバージョンを指定します。このデータは`KanaKanjiCovnerter.toVersionCandidate(_:)`などで用いられます。
+        @available(*, deprecated, renamed: "init(versionString:)", message: "it be removed in AzooKeyKanaKanjiConverter v1.0")
         public init(appVersionString: String) {
-            self.appVersionString = appVersionString
+            self.versionString = "azooKey Version " + appVersionString
         }
-        var appVersionString: String
+
+        /// - parameters:
+        ///   - versionString: アプリのバージョンを示す文字列全体を`"MyIME Version 0.7.1"`のように指定します。このデータは`KanaKanjiCovnerter.toVersionCandidate(_:)`などで用いられます。
+        public init(versionString: String = "Powererd by AzooKeyKanaKanjiConverter") {
+            self.versionString = versionString
+        }
+        var versionString: String
     }
 
     package enum RequestQuery: Sendable {

--- a/Sources/KanaKanjiConverterModule/Converter/VersionCandidate.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/VersionCandidate.swift
@@ -15,9 +15,7 @@ extension KanaKanjiConverter {
     /// - parameters:
     ///  - inputData: 入力情報。
     func toVersionCandidate(_ inputData: ComposingText, options: ConvertRequestOptions) -> [Candidate] {
-
-        if inputData.convertTarget.toKatakana() == "バージョン" {
-            let versionString = "azooKey Version \(options.metadata.appVersionString)"
+        if inputData.convertTarget.toKatakana() == "バージョン", let versionString = options.metadata?.versionString {
             return [Candidate(
                 text: versionString,
                 value: -30,

--- a/Sources/KanaKanjiConverterModuleWithDefaultDictionary/KanaKanjiConverterModuleWithDefaultDictionary.swift
+++ b/Sources/KanaKanjiConverterModuleWithDefaultDictionary/KanaKanjiConverterModuleWithDefaultDictionary.swift
@@ -18,7 +18,7 @@ public extension ConvertRequestOptions {
         memoryDirectoryURL: URL,
         sharedContainerURL: URL,
         textReplacer: TextReplacer = TextReplacer(),
-        metadata: ConvertRequestOptions.Metadata
+        metadata: ConvertRequestOptions.Metadata?
     ) -> Self {
         #if os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
         let dictionaryDirectory = Bundle.module.bundleURL.appendingPathComponent("Dictionary", isDirectory: true)

--- a/Tests/KanaKanjiConverterModuleTests/ConverterTests/ConvesionTests.swift
+++ b/Tests/KanaKanjiConverterModuleTests/ConverterTests/ConvesionTests.swift
@@ -26,7 +26,7 @@ final class ConverterTests: XCTestCase {
             dictionaryResourceURL: Bundle(for: type(of: self)).bundleURL.appendingPathComponent("DictionaryMock", isDirectory: true),
             memoryDirectoryURL: URL(fileURLWithPath: ""),
             sharedContainerURL: URL(fileURLWithPath: ""),
-            metadata: .init(appVersionString: "Tests")
+            metadata: nil
         )
     }
 

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ConverterTests/ConverterTests.swift
@@ -33,7 +33,7 @@ final class ConverterTests: XCTestCase {
             shouldResetMemory: false,
             memoryDirectoryURL: URL(fileURLWithPath: ""),
             sharedContainerURL: URL(fileURLWithPath: ""),
-            metadata: .init(appVersionString: "Tests")
+            metadata: nil
         )
     }
 

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
@@ -32,7 +32,7 @@ final class DicdataStoreTests: XCTestCase {
             shouldResetMemory: false,
             memoryDirectoryURL: URL(fileURLWithPath: ""),
             sharedContainerURL: URL(fileURLWithPath: ""),
-            metadata: .init(appVersionString: "Tests")
+            metadata: nil
         )
     }
 

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ExperimentalTests/InputGraph/LookupGraphTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ExperimentalTests/InputGraph/LookupGraphTests.swift
@@ -11,7 +11,7 @@ import Foundation
 
 final class LookupGraphTests: XCTestCase {
     func requestOptions() -> ConvertRequestOptions {
-        .withDefaultDictionary(requireJapanesePrediction: false, requireEnglishPrediction: false, keyboardLanguage: .ja_JP, learningType: .nothing, memoryDirectoryURL: URL(fileURLWithPath: ""), sharedContainerURL: URL(fileURLWithPath: ""), metadata: .init(appVersionString: "Test"))
+        .withDefaultDictionary(requireJapanesePrediction: false, requireEnglishPrediction: false, keyboardLanguage: .ja_JP, learningType: .nothing, memoryDirectoryURL: URL(fileURLWithPath: ""), sharedContainerURL: URL(fileURLWithPath: ""), metadata: nil)
     }
 
     func setup() -> (dicdataStore: DicdataStore, character2CharId: (Character) -> UInt8) {

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ExperimentalTests/extension Kana2Kanji+InputGraph.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/ExperimentalTests/extension Kana2Kanji+InputGraph.swift
@@ -90,7 +90,7 @@ private extension ConvertGraph.LatticeNode {
 
 final class ExperimentalConversionTests: XCTestCase {
     func requestOptions() -> ConvertRequestOptions {
-        .withDefaultDictionary(requireJapanesePrediction: false, requireEnglishPrediction: false, keyboardLanguage: .ja_JP, learningType: .nothing, memoryDirectoryURL: URL(fileURLWithPath: ""), sharedContainerURL: URL(fileURLWithPath: ""), metadata: .init(appVersionString: "Test"))
+        .withDefaultDictionary(requireJapanesePrediction: false, requireEnglishPrediction: false, keyboardLanguage: .ja_JP, learningType: .nothing, memoryDirectoryURL: URL(fileURLWithPath: ""), sharedContainerURL: URL(fileURLWithPath: ""), metadata: nil)
     }
 
     func testBuildConvertGraph_たいかく() throws {


### PR DESCRIPTION
`ConvertRequestOptions.Metadata`はこれまで何を指定しても「azooKey」が表示されていたが、サードパーティ製アプリケーションでは望ましい挙動ではなかった。そこで新たなAPIを追加した。また、単純に`nil`を指定することもできるようにした。