### PR TITLE
feat: Zenzaiの実装を改善

### DIFF
--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/all_with_prefix_constraint.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/all_with_prefix_constraint.swift
@@ -22,7 +22,6 @@ extension Kana2Kanji {
         debug("新規に計算を行います。inputされた文字列は\(inputData.input.count)文字分の\(inputData.convertTarget)。制約は\(constraint)")
         let count: Int = inputData.input.count
         let result: LatticeNode = LatticeNode.EOSNode
-        let utf16Constraint = Array(constraint.constraint.utf16)
         let nodes: [[LatticeNode]] = (.zero ..< count).map {dicdataStore.getFrozenLOUDSDataInRange(inputData: inputData, from: $0)}
         // 「i文字目から始まるnodes」に対して
         for (i, nodeArray) in nodes.enumerated() {
@@ -50,9 +49,9 @@ extension Kana2Kanji {
                     for index in node.prevs.indices {
                         let newnode: RegisteredNode = node.getRegisteredNode(index, value: node.values[index])
                         if !node.data.metadata.contains(.isLearned) {
-                            let text = newnode.getCandidateData().data.reduce(into: "") { $0.append(contentsOf: $1.word)} + node.data.word
+                            let utf8Text = newnode.getCandidateData().data.reduce(into: []) { $0.append(contentsOf: $1.word.utf8)} + node.data.word.utf8
                             // 最終チェック
-                            let condition = (!constraint.hasEOS && text.utf16.hasPrefix(utf16Constraint)) || (constraint.hasEOS && text == constraint.constraint)
+                            let condition = (!constraint.hasEOS && utf8Text.hasPrefix(constraint.constraint)) || (constraint.hasEOS && utf8Text == constraint.constraint)
                             guard condition else {
                                 continue
                             }
@@ -60,8 +59,8 @@ extension Kana2Kanji {
                         result.prevs.append(newnode)
                     }
                 } else {
-                    let candidates: [[String.UTF16View.Element]] = node.getCandidateData().map {
-                        Array(($0.data.reduce(into: "") { $0.append(contentsOf: $1.word)} + node.data.word).utf16)
+                    let candidates: [[String.UTF8View.Element]] = node.getCandidateData().map {
+                        Array(($0.data.reduce(into: "") { $0.append(contentsOf: $1.word)} + node.data.word).utf8)
                     }
                     // nodeの繋がる次にあり得る全てのnextnodeに対して
                     for nextnode in nodes[nextIndex] {
@@ -80,8 +79,8 @@ extension Kana2Kanji {
                             // 制約 AB 単語 AC  (NG)
                             // ただし、学習データの場合は素通しする
                             if !nextnode.data.metadata.contains(.isLearned) {
-                                let text = candidates[index] + nextnode.data.word.utf16
-                                let condition = (!constraint.hasEOS && (text.hasPrefix(utf16Constraint) || utf16Constraint.hasPrefix(text))) || (constraint.hasEOS && text.count < utf16Constraint.count && utf16Constraint.hasPrefix(text))
+                                let utf8Text = candidates[index] + nextnode.data.word.utf8
+                                let condition = (!constraint.hasEOS && (utf8Text.hasPrefix(constraint.constraint) || constraint.constraint.hasPrefix(utf8Text))) || (constraint.hasEOS && utf8Text.count < constraint.constraint.count && constraint.constraint.hasPrefix(utf8Text))
                                 guard condition else {
                                     continue
                                 }

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/zenzai.swift
@@ -16,10 +16,10 @@ extension Kana2Kanji {
         func getNewConstraint(for newInputData: ComposingText) -> PrefixConstraint {
             if let satisfyingCandidate {
                 var current = newInputData.convertTarget.toKatakana()[...]
-                var constraint = ""
+                var constraint = [UInt8]()
                 for item in satisfyingCandidate.data {
                     if current.hasPrefix(item.ruby) {
-                        constraint += item.word
+                        constraint += item.word.utf8
                         current = current.dropFirst(item.ruby.count)
                     }
                 }
@@ -27,24 +27,28 @@ extension Kana2Kanji {
             } else if newInputData.convertTarget.hasPrefix(inputData.convertTarget) {
                 return self.prefixConstraint
             } else {
-                return PrefixConstraint("")
+                return PrefixConstraint([])
             }
         }
     }
 
-    struct PrefixConstraint: Equatable {
-        init(_ constraint: String, hasEOS: Bool = false) {
+    struct PrefixConstraint: Sendable, Equatable, Hashable, CustomStringConvertible {
+        init(_ constraint: [UInt8], hasEOS: Bool = false) {
             self.constraint = constraint
             self.hasEOS = hasEOS
         }
         
-        var constraint: String
+        var constraint: [UInt8]
         var hasEOS: Bool
+
+        var description: String {
+            "PrefixConstraint(constraint: \"\(String(cString: self.constraint + [0]))\", hasEOS: \(self.hasEOS))"
+        }
     }
 
     /// zenzaiシステムによる完全変換。
     @MainActor func all_zenzai(_ inputData: ComposingText, zenz: Zenz, zenzaiCache: ZenzaiCache?, inferenceLimit: Int) -> (result: LatticeNode, nodes: Nodes, cache: ZenzaiCache) {
-        var constraint = zenzaiCache?.getNewConstraint(for: inputData) ?? PrefixConstraint("")
+        var constraint = zenzaiCache?.getNewConstraint(for: inputData) ?? PrefixConstraint([])
         print("initial constraint", constraint)
         let eosNode = LatticeNode.EOSNode
         var nodes: Kana2Kanji.Nodes = []
@@ -70,7 +74,7 @@ extension Kana2Kanji {
                 print("best was not found!")
                 // Emptyの場合
                 // 制約が満たせない場合は無視する
-                return (eosNode, nodes, ZenzaiCache(inputData, constraint: PrefixConstraint(""), satisfyingCandidate: nil))
+                return (eosNode, nodes, ZenzaiCache(inputData, constraint: PrefixConstraint([]), satisfyingCandidate: nil))
             }
             print("Constrained draft modeling", -start.timeIntervalSinceNow)
             reviewLoop: while true {
@@ -131,29 +135,29 @@ extension Kana2Kanji {
             // 同じ制約が2回連続で出てきたら諦める
             if constraint.constraint == prefixConstraint {
                 print("same constraint:", prefixConstraint)
-                return .return(constraint: PrefixConstraint(""), satisfied: false)
+                return .return(constraint: PrefixConstraint([]), satisfied: false)
             }
             // 制約が得られたので、更新する
             print("update constraint:", prefixConstraint)
             constraint = PrefixConstraint(prefixConstraint)
             // もし制約を満たす候補があるならそれを使って再レビューチャレンジを戦うことで、推論を減らせる
             for i in candidates.indices where i != candidateIndex {
-                if candidates[i].text.hasPrefix(prefixConstraint) {
+                if candidates[i].text.utf8.hasPrefix(prefixConstraint) {
                     print("found \(candidates[i].text) as another retry")
                     return .retry(candidateIndex: i)
                 }
             }
             return .continue
         case .wholeResult(let wholeConstraint):
-            let newConstraint = PrefixConstraint(wholeConstraint, hasEOS: true)
+            let newConstraint = PrefixConstraint(Array(wholeConstraint.utf8), hasEOS: true)
             // 同じ制約が2回連続で出てきたら諦める
             if constraint == newConstraint {
                 print("same constraint:", constraint)
-                return .return(constraint: PrefixConstraint(""), satisfied: false)
+                return .return(constraint: PrefixConstraint([]), satisfied: false)
             }
             // 制約が得られたので、更新する
             print("update whole constraint:", wholeConstraint)
-            constraint = PrefixConstraint(wholeConstraint, hasEOS: true)
+            constraint = PrefixConstraint(Array(wholeConstraint.utf8), hasEOS: true)
             // もし制約を満たす候補があるならそれを使って再レビューチャレンジを戦うことで、推論を減らせる
             for i in candidates.indices where i != candidateIndex {
                 if candidates[i].text == wholeConstraint {

--- a/Sources/KanaKanjiConverterModule/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/Zenz/ZenzContext.swift
@@ -123,7 +123,7 @@ class ZenzContext {
     enum CandidateEvaluationResult: Sendable, Equatable, Hashable {
         case error
         case pass(score: Float)
-        case fixRequired(prefixConstraint: String)
+        case fixRequired(prefixConstraint: [UInt8])
         case wholeResult(String)
     }
 
@@ -209,10 +209,7 @@ class ZenzContext {
                     } else {
                         // adding "\0"
                         cchars += token_to_piece(token: max_token)
-                        let string = String(cString: cchars + [0])
-                        // 要求するべき制約を記述する
-                        let prefixConstraint = String(string.dropFirst(prompt.count))
-                        return .fixRequired(prefixConstraint: prefixConstraint)
+                        return .fixRequired(prefixConstraint: cchars.dropFirst(prompt.utf8.count).map(UInt8.init))
                     }
                 }
             }


### PR DESCRIPTION
Fix #101 

* 実装を改善し、単語の途中に非argmaxな文字が出現した場合の処理を安定化
* 読み制約の実装を改善し、1文字を複数のバイトレベルトークンでエンコードした場合にも安定した処理ができるように改善