### PR TITLE
feat: Zenzaiの制約付き変換において計算から除外する候補を減らした

### DIFF
--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/all_with_prefix_constraint.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/all_with_prefix_constraint.swift
@@ -30,9 +30,6 @@ extension Kana2Kanji {
                 if node.prevs.isEmpty {
                     continue
                 }
-                if self.dicdataStore.shouldBeRemoved(data: node.data) {
-                    continue
-                }
                 // 生起確率を取得する。
                 let wValue: PValue = node.data.value()
                 if i == 0 {
@@ -64,10 +61,6 @@ extension Kana2Kanji {
                     }
                     // nodeの繋がる次にあり得る全てのnextnodeに対して
                     for nextnode in nodes[nextIndex] {
-                        // この関数はこの時点で呼び出して、後のnode.registered.isEmptyで最終的に弾くのが良い。
-                        if self.dicdataStore.shouldBeRemoved(data: nextnode.data) {
-                            continue
-                        }
                         // クラスの連続確率を計算する。
                         let ccValue: PValue = self.dicdataStore.getCCValue(node.data.rcid, nextnode.data.lcid)
                         // nodeの持っている全てのprevnodeに対して


### PR DESCRIPTION
計算量の削減のため、通常の変換ではコストが高すぎる候補を初めから除外していた。しかし、Zenzaiの制約付き変換においてはこれによって制約を満たす候補が作れなくなるケースが存在した。

例えば「村に鉄道を引いて『我田引鉄』する議員」という文章では、「我田引鉄」が辞書登録外であるため、「引」「鉄」を組み合わせる必要がある。しかし、「引」単体はコストが高いため、変換から除外される。これによって制約を満たす候補が作れなくなってしまう。

そこでこのPRでは制約付き変換において上記の除外処理を削除した。制約付き変換はそもそも接頭辞制約によって候補が強く絞り込まれるため、変換候補をわざわざ削減しなくても、高速に処理できる。