### PR TITLE
fix: firstClauseResultsとして得られる結果が長さではなくvalueでソートされる挙動を変更

### DIFF
--- a/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
@@ -572,7 +572,15 @@ import SwiftUtils
             item.withActions(self.getAppropriateActions(item))
             item.parseTemplate()
         }
-        return ConversionResult(mainResults: result, firstClauseResults: Array(clause_candidates))
+        // 文節のみ変換するパターン（上位5件）
+        let firstClauseResults = self.getUniqueCandidate(clauseCandidates).min(count: 5) {
+            if $0.correspondingCount == $1.correspondingCount {
+                $0.value > $1.value
+            } else {
+                $0.correspondingCount > $1.correspondingCount
+            }
+        }
+        return ConversionResult(mainResults: result, firstClauseResults: firstClauseResults)
     }
 
     /// 入力からラティスを構築する関数。状況に応じて呼ぶ関数を分ける。

--- a/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
@@ -512,7 +512,13 @@ import SwiftUtils
         // 重複のない変換候補を作成するための集合
         var seenCandidate: Set<String> = full_candidate.mapSet {$0.text}
         // 文節のみ変換するパターン（上位5件）
-        let clause_candidates = self.getUniqueCandidate(clauseCandidates, seenCandidates: seenCandidate).min(count: 5, sortedBy: {$0.value > $1.value})
+        let clause_candidates = self.getUniqueCandidate(clauseCandidates, seenCandidates: seenCandidate).min(count: 5) {
+            if $0.correspondingCount == $1.correspondingCount {
+                $0.value > $1.value
+            } else {
+                $0.correspondingCount > $1.correspondingCount
+            }
+        }
         seenCandidate.formUnion(clause_candidates.map {$0.text})
 
         // 最初の辞書データ


### PR DESCRIPTION
現在、firstClauseResultsとして得られる結果は長さではなくvalueでソートされているが、これでは有用な候補が得られない。そこでまずcorrespondingCountでソートし、その中でvalueでソートするように実装を修正した。