### PR TITLE
fix: retryの候補として不適切そうな単語を無視する処理を追加

### DIFF
--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/zenzai.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/zenzai.swift
@@ -195,9 +195,9 @@ extension Kana2Kanji {
             constraint = PrefixConstraint(prefixConstraint)
             print("update constraint:", constraint)
             // もし制約を満たす候補があるならそれを使って再レビューチャレンジを戦うことで、推論を減らせる
-            for i in candidates.indices where i != candidateIndex {
-                if candidates[i].text.utf8.hasPrefix(prefixConstraint) {
-                    print("found \(candidates[i].text) as another retry")
+            for (i, candidate) in candidates.indexed() where i != candidateIndex {
+                if candidate.text.utf8.hasPrefix(prefixConstraint) && self.heuristicRetryValidation(candidate.text) {
+                    print("found \(candidate.text) as another retry")
                     return .retry(candidateIndex: i)
                 }
             }
@@ -221,5 +221,13 @@ extension Kana2Kanji {
             }
             return .continue
         }
+    }
+
+    /// リトライの候補に対して恣意的なバリデーションを実施する
+    private func heuristicRetryValidation(_ text: String) -> Bool {
+        if text.contains("\u{3099}") || text.contains("\u{309A}") {
+            return false
+        }
+        return true
     }
 }


### PR DESCRIPTION
fix #126 