### PR TITLE
feat: Zenzaiでユーザ辞書を有効化

### DIFF
--- a/Sources/KanaKanjiConverterModule/DicdataStore/DicdataElement.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/DicdataElement.swift
@@ -78,7 +78,17 @@ public struct DicdataElement: Equatable, Hashable, Sendable {
 
 extension DicdataElement: CustomDebugStringConvertible {
     public var debugDescription: String {
-        "(ruby: \(self.ruby), word: \(self.word), cid: (\(self.lcid), \(self.rcid)), mid: \(self.mid), value: \(self.baseValue)+\(self.adjust)=\(self.value()), metadata: (isLearned: \(self.metadata.contains(.isLearned))))"
+        "("
+        + "ruby: \(self.ruby), "
+        + "word: \(self.word), "
+        + "cid: (\(self.lcid), \(self.rcid)), "
+        + "mid: \(self.mid), "
+        + "value: \(self.baseValue)+\(self.adjust)=\(self.value()), "
+        + "metadata: ("
+        + "isLearned: \(self.metadata.contains(.isLearned)), "
+        + "isFromUserDictionary: \(self.metadata.contains(.isFromUserDictionary))"
+        + ")"
+        + ")"
     }
 }
 
@@ -91,4 +101,6 @@ public struct DicdataElementMetadata: OptionSet, Sendable, Hashable, Equatable {
     public static let empty: Self = []
     /// 学習データから得られた候補にはこのフラグを立てる
     public static let isLearned = DicdataElementMetadata(rawValue: 1 << 0) // 1
+    /// ユーザ辞書から得られた候補にはこのフラグを立てる
+    public static let isFromUserDictionary = DicdataElementMetadata(rawValue: 1 << 1) // 2
 }

--- a/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
@@ -218,6 +218,11 @@ public final class DicdataStore {
                 $0.metadata = .isLearned
             }
         }
+        if identifier == "user" {
+            data.mutatingForeach {
+                $0.metadata = .isFromUserDictionary
+            }
+        }
         return data
     }
 

--- a/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
@@ -313,7 +313,7 @@ public final class DicdataStore {
                 dicdata.append(contentsOf: result)
             }
             do {
-                let result = self.getMatchOSUserDict(segments[i - fromIndex])
+                let result = self.getMatchDynamicUserDict(segments[i - fromIndex])
                 for item in result {
                     stringToInfo[Array(item.ruby)] = (i, 0)
                 }
@@ -365,7 +365,7 @@ public final class DicdataStore {
         }
 
         // MARK: 誤り訂正なし
-        var stringToEndIndex = inputData.getRanges(fromIndex, rightIndexRange: toIndexLeft ..< toIndexRight)
+        let stringToEndIndex = inputData.getRanges(fromIndex, rightIndexRange: toIndexLeft ..< toIndexRight)
         // MARK: 検索対象を列挙していく。
         guard let (minString, maxString) = stringToEndIndex.keys.minAndMax(by: {$0.count < $1.count}) else {
             return [characterNode]
@@ -387,7 +387,9 @@ public final class DicdataStore {
         }
         for i in toIndexLeft ..< toIndexRight {
             dicdata.append(contentsOf: self.getWiseDicdata(convertTarget: segments[i - fromIndex], inputData: inputData, inputRange: fromIndex ..< i + 1))
-            dicdata.append(contentsOf: self.getMatchOSUserDict(segments[i - fromIndex]))
+        }
+        for item in stringToEndIndex {
+            dicdata.append(contentsOf: self.getMatchDynamicUserDict(String(item.key)))
         }
         if fromIndex == .zero {
             return dicdata.compactMap {
@@ -484,7 +486,7 @@ public final class DicdataStore {
         }
 
         dicdata.append(contentsOf: self.getWiseDicdata(convertTarget: segment, inputData: inputData, inputRange: fromIndex ..< toIndex + 1))
-        dicdata.append(contentsOf: self.getMatchOSUserDict(segment))
+        dicdata.append(contentsOf: self.getMatchDynamicUserDict(segment))
 
         if fromIndex == .zero {
             let result: [LatticeNode] = dicdata.map {
@@ -706,13 +708,13 @@ public final class DicdataStore {
         }
     }
 
-    /// OSのユーザ辞書からrubyに等しい語を返す。
-    func getMatchOSUserDict(_ ruby: some StringProtocol) -> [DicdataElement] {
+    /// 動的ユーザ辞書からrubyに等しい語を返す。
+    func getMatchDynamicUserDict(_ ruby: some StringProtocol) -> [DicdataElement] {
         self.dynamicUserDict.filter {$0.ruby == ruby}
     }
 
-    /// OSのユーザ辞書からrubyに先頭一致する語を返す。
-    func getPrefixMatchOSUserDict(_ ruby: some StringProtocol) -> [DicdataElement] {
+    /// 動的ユーザ辞書からrubyに先頭一致する語を返す。
+    func getPrefixMatchDynamicUserDict(_ ruby: some StringProtocol) -> [DicdataElement] {
         self.dynamicUserDict.filter {$0.ruby.hasPrefix(ruby)}
     }
 

--- a/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
@@ -87,6 +87,9 @@ public final class DicdataStore {
             self.closeKeyboard()
         case .importOSUserDict(let dicdata), .importDynamicUserDict(let dicdata):
             self.dynamicUserDict = dicdata
+            self.dynamicUserDict.mutatingForeach {
+                $0.metadata = .isFromUserDictionary
+            }
         case let .forgetMemory(candidate):
             self.learningManager.forgetMemory(data: candidate.data)
             // loudsの処理があるので、リセットを実施する

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/all_with_prefix_constraint.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/all_with_prefix_constraint.swift
@@ -46,7 +46,7 @@ extension Kana2Kanji {
                     for index in node.prevs.indices {
                         let newnode: RegisteredNode = node.getRegisteredNode(index, value: node.values[index])
                         // 学習データやユーザ辞書由来の場合は素通しする
-                        if !node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                        if node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                             let utf8Text = newnode.getCandidateData().data.reduce(into: []) { $0.append(contentsOf: $1.word.utf8)} + node.data.word.utf8
                             // 最終チェック
                             let condition = (!constraint.hasEOS && utf8Text.hasPrefix(constraint.constraint)) || (constraint.hasEOS && utf8Text == constraint.constraint)
@@ -72,7 +72,7 @@ extension Kana2Kanji {
                             // 制約 AB 単語 A   (OK)
                             // 制約 AB 単語 AC  (NG)
                             // ただし、学習データやユーザ辞書由来の場合は素通しする
-                            if !nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
+                            if nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                                 let utf8Text = candidates[index] + nextnode.data.word.utf8
                                 let condition = (!constraint.hasEOS && (utf8Text.hasPrefix(constraint.constraint) || constraint.constraint.hasPrefix(utf8Text))) || (constraint.hasEOS && utf8Text.count < constraint.constraint.count && constraint.constraint.hasPrefix(utf8Text))
                                 guard condition else {

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/all_with_prefix_constraint.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/all_with_prefix_constraint.swift
@@ -45,7 +45,8 @@ extension Kana2Kanji {
                 if nextIndex == count {
                     for index in node.prevs.indices {
                         let newnode: RegisteredNode = node.getRegisteredNode(index, value: node.values[index])
-                        if !node.data.metadata.contains(.isLearned) {
+                        // 学習データやユーザ辞書由来の場合は素通しする
+                        if !node.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                             let utf8Text = newnode.getCandidateData().data.reduce(into: []) { $0.append(contentsOf: $1.word.utf8)} + node.data.word.utf8
                             // 最終チェック
                             let condition = (!constraint.hasEOS && utf8Text.hasPrefix(constraint.constraint)) || (constraint.hasEOS && utf8Text == constraint.constraint)
@@ -70,8 +71,8 @@ extension Kana2Kanji {
                             // 制約 AB 単語 ABC (OK)
                             // 制約 AB 単語 A   (OK)
                             // 制約 AB 単語 AC  (NG)
-                            // ただし、学習データの場合は素通しする
-                            if !nextnode.data.metadata.contains(.isLearned) {
+                            // ただし、学習データやユーザ辞書由来の場合は素通しする
+                            if !nextnode.data.metadata.isDisjoint(with: [.isLearned, .isFromUserDictionary]) {
                                 let utf8Text = candidates[index] + nextnode.data.word.utf8
                                 let condition = (!constraint.hasEOS && (utf8Text.hasPrefix(constraint.constraint) || constraint.constraint.hasPrefix(utf8Text))) || (constraint.hasEOS && utf8Text.count < constraint.constraint.count && constraint.constraint.hasPrefix(utf8Text))
                                 guard condition else {

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/mid_composition_prediction.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/mid_composition_prediction.swift
@@ -40,7 +40,7 @@ extension Kana2Kanji {
             datas = Array(prepart.data.prefix(count))
         }
 
-        let osuserdict: [DicdataElement] = dicdataStore.getPrefixMatchOSUserDict(lastRuby)
+        let osuserdict: [DicdataElement] = dicdataStore.getPrefixMatchDynamicUserDict(lastRuby)
 
         let lastCandidate: Candidate = prepart.isEmpty ? Candidate(text: "", value: .zero, correspondingCount: 0, lastMid: MIDData.EOS.mid, data: []) : self.processClauseCandidate(prepart)
         let lastRcid: Int = lastCandidate.data.last?.rcid ?? CIDData.EOS.cid

--- a/Sources/KanaKanjiConverterModule/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/Zenz/ZenzContext.swift
@@ -256,7 +256,7 @@ class ZenzContext {
         var conditions: [String] = []
         // ユーザ辞書の内容がある場合はこれを条件に追加
         if !userDictionaryPrompt.isEmpty {
-            conditions.append("ユーザ辞書:\(userDictionaryPrompt)")
+            conditions.append("辞書:\(userDictionaryPrompt)")
         }
         // プロフィールがある場合はこれを条件に追加
         if case .v2(let mode) = versionDependentConfig, let profile = mode.profile, !profile.isEmpty {

--- a/Sources/KanaKanjiConverterModule/Zenz/ZenzContext.swift
+++ b/Sources/KanaKanjiConverterModule/Zenz/ZenzContext.swift
@@ -256,7 +256,7 @@ class ZenzContext {
         var conditions: [String] = []
         // ユーザ辞書の内容がある場合はこれを条件に追加
         if !userDictionaryPrompt.isEmpty {
-            conditions.append("ユーザ辞書:\(consume userDictionaryPrompt)")
+            conditions.append("ユーザ辞書:\(userDictionaryPrompt)")
         }
         // プロフィールがある場合はこれを条件に追加
         if case .v2(let mode) = versionDependentConfig, let profile = mode.profile, !profile.isEmpty {


### PR DESCRIPTION
* `DicdataElement`にユーザ辞書の属性を追加
* 左文脈としてユーザ辞書情報を追加する機能を実装
* `evaluate`コマンドの実装を変更し、jsonファイルを受け取るように変更。また、ユーザ辞書を加味した評価を可能に。