### PR TITLE
fix: Zenzaiが無い状態でも動的ユーザ辞書を有効化

### DIFF
--- a/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
+++ b/Sources/KanaKanjiConverterModule/Converter/KanaKanjiConverter.swift
@@ -608,10 +608,15 @@ import SwiftUtils
             self.previousInputData = inputData
             return (result, nodes)
         }
+        #if os(iOS)
+        let needTypoCorrection = true
+        #else
+        let needTypoCorrection = false
+        #endif
 
         guard let previousInputData else {
             debug("convertToLattice: 新規計算用の関数を呼びますA")
-            let result = converter.kana2lattice_all(inputData, N_best: N_best)
+            let result = converter.kana2lattice_all(inputData, N_best: N_best, needTypoCorrection: needTypoCorrection)
             self.previousInputData = inputData
             return result
         }
@@ -628,7 +633,7 @@ import SwiftUtils
         // 文節確定の後の場合
         if let completedData, previousInputData.inputHasSuffix(inputOf: inputData) {
             debug("convertToLattice: 文節確定用の関数を呼びます、確定された文節は\(completedData)")
-            let result = converter.kana2lattice_afterComplete(inputData, completedData: completedData, N_best: N_best, previousResult: (inputData: previousInputData, nodes: nodes))
+            let result = converter.kana2lattice_afterComplete(inputData, completedData: completedData, N_best: N_best, previousResult: (inputData: previousInputData, nodes: nodes), needTypoCorrection: needTypoCorrection)
             self.previousInputData = inputData
             self.completedData = nil
             return result
@@ -650,7 +655,7 @@ import SwiftUtils
         // 一文字変わった場合
         if diff.deleted > 0 {
             debug("convertToLattice: 最後尾文字置換用の関数を呼びます、差分は\(diff)")
-            let result = converter.kana2lattice_changed(inputData, N_best: N_best, counts: (diff.deleted, diff.addedCount), previousResult: (inputData: previousInputData, nodes: nodes))
+            let result = converter.kana2lattice_changed(inputData, N_best: N_best, counts: (diff.deleted, diff.addedCount), previousResult: (inputData: previousInputData, nodes: nodes), needTypoCorrection: needTypoCorrection)
             self.previousInputData = inputData
             return result
         }
@@ -658,7 +663,7 @@ import SwiftUtils
         // 1文字増やした場合
         if diff.deleted == 0 && diff.addedCount != 0 {
             debug("convertToLattice: 最後尾追加用の関数を呼びます、追加文字数は\(diff.addedCount)")
-            let result = converter.kana2lattice_added(inputData, N_best: N_best, addedCount: diff.addedCount, previousResult: (inputData: previousInputData, nodes: nodes))
+            let result = converter.kana2lattice_added(inputData, N_best: N_best, addedCount: diff.addedCount, previousResult: (inputData: previousInputData, nodes: nodes), needTypoCorrection: needTypoCorrection)
             self.previousInputData = inputData
             return result
         }
@@ -666,7 +671,7 @@ import SwiftUtils
         // 一文字増やしていない場合
         if true {
             debug("convertToLattice: 新規計算用の関数を呼びますB")
-            let result = converter.kana2lattice_all(inputData, N_best: N_best)
+            let result = converter.kana2lattice_all(inputData, N_best: N_best, needTypoCorrection: needTypoCorrection)
             self.previousInputData = inputData
             return result
         }

--- a/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
+++ b/Sources/KanaKanjiConverterModule/DicdataStore/DicdataStore.swift
@@ -415,13 +415,16 @@ public final class DicdataStore {
     ///   - inputData: 入力データ
     ///   - from: 始点
     ///   - to: 終点
-    public func getLOUDSData(inputData: ComposingText, from fromIndex: Int, to toIndex: Int) -> [LatticeNode] {
+    public func getLOUDSData(inputData: ComposingText, from fromIndex: Int, to toIndex: Int, needTypoCorrection: Bool) -> [LatticeNode] {
         if toIndex - fromIndex > self.maxlength || fromIndex > toIndex {
             return []
         }
         let segment = inputData.input[fromIndex...toIndex].reduce(into: "") {$0.append($1.character)}.toKatakana()
 
-        let string2penalty = inputData.getRangeWithTypos(fromIndex, toIndex)
+        // TODO: 最適化の余地あり
+        let string2penalty = inputData.getRangeWithTypos(fromIndex, toIndex).filter {
+            needTypoCorrection || $0.value == 0.0
+        }
 
         // MARK: 検索によって得たindicesから辞書データを実際に取り出していく
         // 先頭の文字: そこで検索したい文字列の集合

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/added_last_1_character.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/added_last_1_character.swift
@@ -27,7 +27,7 @@ extension Kana2Kanji {
     /// (3)(1)のregisterされた結果をresultノードに追加していく。この際EOSとの連接コストを計算しておく。
     ///
     /// (4)ノードをアップデートした上で返却する。
-    func kana2lattice_addedLast(_ inputData: ComposingText, N_best: Int, previousResult: (inputData: ComposingText, nodes: Nodes) ) -> (result: LatticeNode, nodes: Nodes) {
+    func kana2lattice_addedLast(_ inputData: ComposingText, N_best: Int, previousResult: (inputData: ComposingText, nodes: Nodes), needTypoCorrection: Bool) -> (result: LatticeNode, nodes: Nodes) {
         debug("一文字追加。内部文字列は\(inputData.input).\(previousResult.nodes.map {($0.first?.data.ruby, $0.first?.inputRange)})")
         // (0)
         var nodes = previousResult.nodes
@@ -35,7 +35,7 @@ extension Kana2Kanji {
 
         // (1)
         let addedNodes: [[LatticeNode]] = (0...count).map {(i: Int) in
-            self.dicdataStore.getLOUDSData(inputData: inputData, from: i, to: count)
+            self.dicdataStore.getLOUDSData(inputData: inputData, from: i, to: count, needTypoCorrection: needTypoCorrection)
         }
 
         // ココが一番時間がかかっていた。

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/added_last_n_character.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/added_last_n_character.swift
@@ -28,10 +28,10 @@ extension Kana2Kanji {
     /// (3)(1)のregisterされた結果をresultノードに追加していく。この際EOSとの連接コストを計算しておく。
     ///
     /// (4)ノードをアップデートした上で返却する。
-    func kana2lattice_added(_ inputData: ComposingText, N_best: Int, addedCount: Int, previousResult: (inputData: ComposingText, nodes: Nodes)) -> (result: LatticeNode, nodes: Nodes) {
+    func kana2lattice_added(_ inputData: ComposingText, N_best: Int, addedCount: Int, previousResult: (inputData: ComposingText, nodes: Nodes), needTypoCorrection: Bool) -> (result: LatticeNode, nodes: Nodes) {
         debug("\(addedCount)文字追加。追加されたのは「\(inputData.input.suffix(addedCount))」")
         if addedCount == 1 {
-            return kana2lattice_addedLast(inputData, N_best: N_best, previousResult: previousResult)
+            return kana2lattice_addedLast(inputData, N_best: N_best, previousResult: previousResult, needTypoCorrection: needTypoCorrection)
         }
         // (0)
         var nodes = previousResult.nodes
@@ -42,7 +42,8 @@ extension Kana2Kanji {
             self.dicdataStore.getLOUDSDataInRange(
                 inputData: inputData,
                 from: i,
-                toIndexRange: (max(previousResult.inputData.input.count, i) ..< max(previousResult.inputData.input.count, min(count, i + self.dicdataStore.maxlength + 1)))
+                toIndexRange: (max(previousResult.inputData.input.count, i) ..< max(previousResult.inputData.input.count, min(count, i + self.dicdataStore.maxlength + 1))),
+                needTypoCorrection: needTypoCorrection
             )
         }
 

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/all.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/all.swift
@@ -29,7 +29,7 @@ extension Kana2Kanji {
     /// (3)(1)のregisterされた結果をresultノードに追加していく。この際EOSとの連接計算を行っておく。
     ///
     /// (4)ノードをアップデートした上で返却する。
-    func kana2lattice_all(_ inputData: ComposingText, N_best: Int, needTypoCorrection: Bool = true) -> (result: LatticeNode, nodes: Nodes) {
+    func kana2lattice_all(_ inputData: ComposingText, N_best: Int, needTypoCorrection: Bool) -> (result: LatticeNode, nodes: Nodes) {
         debug("新規に計算を行います。inputされた文字列は\(inputData.input.count)文字分の\(inputData.convertTarget)")
         let count: Int = inputData.input.count
         let result: LatticeNode = LatticeNode.EOSNode

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/changed_last_n_character.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/changed_last_n_character.swift
@@ -24,7 +24,7 @@ extension Kana2Kanji {
     ///
     /// (5)ノードをアップデートした上で返却する。
 
-    func kana2lattice_changed(_ inputData: ComposingText, N_best: Int, counts: (deleted: Int, added: Int), previousResult: (inputData: ComposingText, nodes: Nodes)) -> (result: LatticeNode, nodes: Nodes) {
+    func kana2lattice_changed(_ inputData: ComposingText, N_best: Int, counts: (deleted: Int, added: Int), previousResult: (inputData: ComposingText, nodes: Nodes), needTypoCorrection: Bool) -> (result: LatticeNode, nodes: Nodes) {
         // (0)
         let count = inputData.input.count
         let commonCount = previousResult.inputData.input.count - counts.deleted
@@ -39,7 +39,7 @@ extension Kana2Kanji {
         }
         // (2)
         let addedNodes: [[LatticeNode]] = (0..<count).map {(i: Int) in
-            self.dicdataStore.getLOUDSDataInRange(inputData: inputData, from: i, toIndexRange: max(commonCount, i) ..< count)
+            self.dicdataStore.getLOUDSDataInRange(inputData: inputData, from: i, toIndexRange: max(commonCount, i) ..< count, needTypoCorrection: needTypoCorrection)
         }
 
         // (3)

--- a/Sources/KanaKanjiConverterModule/Kana2Kanji/completed_first.swift
+++ b/Sources/KanaKanjiConverterModule/Kana2Kanji/completed_first.swift
@@ -15,7 +15,7 @@ extension Kana2Kanji {
     /// (1)まず、計算済みnodeの確定分以降を取り出し、registeredにcompletedDataの値を反映したBOSにする。
     ///
     /// (2)次に、再度計算して良い候補を得る。
-    func kana2lattice_afterComplete(_ inputData: ComposingText, completedData: Candidate, N_best: Int, previousResult: (inputData: ComposingText, nodes: Nodes)) -> (result: LatticeNode, nodes: Nodes) {
+    func kana2lattice_afterComplete(_ inputData: ComposingText, completedData: Candidate, N_best: Int, previousResult: (inputData: ComposingText, nodes: Nodes), needTypoCorrection: Bool) -> (result: LatticeNode, nodes: Nodes) {
         debug("確定直後の変換、前は：", previousResult.inputData, "後は：", inputData)
         let count = inputData.input.count
         // (1)

--- a/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
+++ b/Tests/KanaKanjiConverterModuleWithDefaultDictionaryTests/DicdataStoreTests/DicdataStoreTests.swift
@@ -59,7 +59,7 @@ final class DicdataStoreTests: XCTestCase {
         for (key, word) in mustWords {
             var c = ComposingText()
             c.insertAtCursorPosition(key, inputStyle: .direct)
-            let result = dicdataStore.getLOUDSData(inputData: c, from: 0, to: c.input.endIndex - 1)
+            let result = dicdataStore.getLOUDSData(inputData: c, from: 0, to: c.input.endIndex - 1, needTypoCorrection: false)
             // 冗長な書き方だが、こうすることで「どの項目でエラーが発生したのか」がはっきりするため、こう書いている。
             XCTAssertEqual(result.first(where: {$0.data.word == word})?.data.word, word)
         }
@@ -80,7 +80,7 @@ final class DicdataStoreTests: XCTestCase {
         for (key, word) in mustWords {
             var c = ComposingText()
             c.insertAtCursorPosition(key, inputStyle: .direct)
-            let result = dicdataStore.getLOUDSData(inputData: c, from: 0, to: c.input.endIndex - 1)
+            let result = dicdataStore.getLOUDSData(inputData: c, from: 0, to: c.input.endIndex - 1, needTypoCorrection: false)
             XCTAssertNil(result.first(where: {$0.data.word == word && $0.data.ruby == key}))
         }
     }


### PR DESCRIPTION
* macOSでは誤り訂正を完全に無効化することでZenzai利用時と同一のパスに入るようにした